### PR TITLE
Add support for SSP 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add `login_with` key in discopower definitions
+
+### Fixed
+
+- Load JavaScript scripts with the new way
+
+### Changed
+
+- Move `ribbon_text` definition to config file
+
 ## [v-eosc-2.0.0](https://github.com/EGI-Foundation/simplesamlphp-module-themeeosc/compare/v-eosc-1.1.1...v-eosc-2.0.0) - 2020-02-10
 
 ### Added

--- a/config-example/module_themeeosc.php
+++ b/config-example/module_themeeosc.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This is example configuration of SimpleSAMLphp themevanila.
  * Copy this file to default config directory and edit the properties.
@@ -6,6 +7,7 @@
  * copy command (from SimpleSAML base dir)
  * cp modules/themeeosc/module_themeeosc.php config/
  */
+
 $config = array(
     'cookiePolicy' => array(
         //array('type' => 'Session State', 'provider' => 'aai.eosc-portal.eu', 'name' => 'rciam_proxy_authtoken, rciam_google_proxy_authtoken, rciam_google_proxy_authtoken, rciam_facebook_proxy_authtoken, rciam_linkedin_proxy_authtoken, rciam_orcid_proxy_authtoken', 'thirdParty' => false, 'category' => 'Session', 'purpose' => 'Preserve user authentication token to prevent session fixation attacks'),
@@ -19,7 +21,6 @@ $config = array(
         array('type' => 'Preferences', 'provider' => 'aai.eosc-portal.eu', 'name' => 'i18next', 'thirdParty' => false, 'category' => 'Session', 'purpose' => 'Preserve preferred language for EOSC Portal AAI OpenID Connect Provider'),
         array('type' => 'Session State', 'provider' => 'aai.eosc-portal.eu', 'name' => 'JSESSIONID', 'thirdParty' => false, 'category' => 'Session', 'purpose' => 'Preserve user session ID to retrieve session information')
     ),
-    'enable_cookies_banner' => false
+    'enable_cookies_banner' => false,
+    'ribbon_text' => '',
 );
-
-?>

--- a/dictionaries/default.definition.json
+++ b/dictionaries/default.definition.json
@@ -10,8 +10,5 @@
   },
   "logo_link_url": {
     "en": ""
-  },
-  "ribbon_text": {
-    "en": ""
   }
 }

--- a/dictionaries/discopower.definition.json
+++ b/dictionaries/discopower.definition.json
@@ -43,5 +43,8 @@
   },
   "contact_us_url": {
     "en": "https://eosc-portal.eu/contact-us"
+  },
+  "login_with": {
+    "en": "Log in with"
   }
 }

--- a/themes/ssp/default/includes/header.php
+++ b/themes/ssp/default/includes/header.php
@@ -1,6 +1,7 @@
 <?php
 
-
+$themeConfig = SimpleSAML\Configuration::getConfig('module_themeeosc.php');
+$ribbonText = $themeConfig->getValue('ribbon_text');
 
 /**
  * Support the htmlinject hook, which allows modules to change header, pre and post body on all pages.
@@ -127,9 +128,9 @@ if($onLoad !== '') {
 
 <div class="header">
 <?php
-  if (strpos($this->t('{themeeosc:default:ribbon_text}'), 'not translated') === FALSE || $this->t('{themeeosc:default:ribbon_text}')) {
+  if (!empty($ribbonText)) {
     echo '<div class="corner-ribbon red">';
-    echo $this->t('{themeeosc:default:ribbon_text}');
+    echo $ribbonText;
     echo '</div>';
   }
   ?>

--- a/themes/ssp/discopower/disco.tpl.php
+++ b/themes/ssp/discopower/disco.tpl.php
@@ -141,7 +141,7 @@ if (!empty($faventry)) {
                 <input type="hidden" name="returnIDParam" value="' . htmlspecialchars($this->data['returnIDParam']) . '" />
                 <input type="hidden" name="idpentityid" value="' . htmlspecialchars($faventry['entityid']) . '" />
                 <input type="submit" name="formsubmit" id="favouritesubmit" class="ssp-btn ssp-btn__action text-uppercase" value="'
-                  . $this->t('login_at') . ' ' . htmlspecialchars(getTranslatedName($this, $faventry)) . '" />
+                  . $this->t('{themeeosc:discopower:login_with}') . ' ' . htmlspecialchars(getTranslatedName($this, $faventry)) . '" />
               </form>
             </div>
             <div class="row text-center ssp-modal-or">' . (strpos($this->t('{themeeosc:discopower:or}'), 'not translated') === FALSE ? $this->t('{themeeosc:discopower:or}') : '') . '</div>

--- a/themes/ssp/discopower/disco.tpl.php
+++ b/themes/ssp/discopower/disco.tpl.php
@@ -27,19 +27,16 @@ if(!array_key_exists('header', $this->data)) {
   $this->data['header'] = 'selectidp';
 }
 $this->data['header'] = $this->t($this->data['header']);
-$this->data['jquery'] = ['core' => true, 'ui' => true, 'css' => true];
-
-
-$this->data['head'] = '<script type="text/javascript" src="'.
-    SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery.livesearch.js').'"></script>'."\n";
-$this->data['head'] .= '<script type="text/javascript" src="'.
-    SimpleSAML\Module::getModuleURL('discopower/assets/js/' . $this->data['score'].'.js')  . '"></script>'."\n";
-
-$this->data['head'] .= $this->data['search'];
 
 if (!empty($faventry)) $this->data['autofocus'] = 'favouritesubmit';
 
 $this->includeAtTemplateBase('includes/header.php');
+
+$this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery.livesearch.js').'"></script>'."\n";
+$this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/'.$this->data['score'].'.js') . '"></script>'."\n";
+
 
 function showEntry($t, $metadata, $favourite = FALSE, $withIcon = FALSE) {
 

--- a/themes/ssp/discopower/disco.tpl.php
+++ b/themes/ssp/discopower/disco.tpl.php
@@ -33,6 +33,14 @@ if (!empty($faventry)) $this->data['autofocus'] = 'favouritesubmit';
 $this->includeAtTemplateBase('includes/header.php');
 
 $this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery-1.12.4.min.js').'"></script>'."\n";
+$this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery-ui-1.12.1.min.js').'"></script>'."\n";
+$this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery.livesearch.js').'"></script>'."\n";
+$this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
+    SimpleSAML\Module::getModuleURL('discopower/assets/js/tablist.js').'"></script>'."\n";
+$this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
     SimpleSAML\Module::getModuleURL('discopower/assets/js/jquery.livesearch.js').'"></script>'."\n";
 $this->data['htmlinject']['htmlContentPost'][] = '<script type="text/javascript" src="'.
     SimpleSAML\Module::getModuleURL('discopower/assets/js/'.$this->data['score'].'.js') . '"></script>'."\n";

--- a/themes/ssp/discopower/disco.tpl.php
+++ b/themes/ssp/discopower/disco.tpl.php
@@ -197,7 +197,7 @@ foreach( $this->data['idplist'] AS $tab => $slist) {
           $list_items .= (showEntry($this, $idpentry, FALSE, TRUE));
         }
       }
-      if($idps_in_searchable_list_index < $idps_with_logos_index) {
+      if(!empty($idps_in_searchable_list_index) && $idps_in_searchable_list_index < $idps_with_logos_index) {
         $or = '<div class="text-center ssp-line-or-line ssp-line-or-line--top"><span class="ssp-line-or-line__or">' . (strpos($this->t('{themeeosc:discopower:or}'), 'not translated') === FALSE ? $this->t('{themeeosc:discopower:or}') : '') . '</span></div>';
         echo $top . $or . $list_open . $list_items . $close_list . $close;
       }


### PR DESCRIPTION
This PR contains the following changes:
- Replace `data['header']` with `data['htmlinject']['htmlContentPost']` to load javascript scripts to templates
- Add paths for jQuery
- Add `login_with` key in discopower definitions
- Move `ribbon_text` to config file